### PR TITLE
Implement default OG properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Metatags plugin for glFusion - Changelog
 
-## Ver 1.1.0 (October 6, 2017)
+## Ver 1.2.0 (TBD)
+- Implement property tags to allow OpenGraph elements.
+- Update priority for defaults and autotags.
 
+## Ver 1.1.0 (October 6, 2017)
 - Implement plugin_autotag function, support all content types
 - Set tags via outputHandler class with priority
 - Remove PHP in Staticpage option, no longer needed

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # MetaTags Plugin for glFusion
-## Version: 1.1.0
+## Version: 1.2.0
 
 For the latest documentation, please see https://www.glfusion.org/wiki/glfusion:plugins:metatags:start
 
-Requires glFusion 1.7.0 or higher.
+Requires glFusion 2.0.0 or higher.
 
 ## Overview
 
-The Metatags plugin allows you to set metatags in the  meta tags in HTML
+The Metatags plugin allows you to set metatags in the meta tags in HTML
 &lt;head&gt; section according to the page content. Metatags are implemented
 using autotags and support any content type;
 
 ```
 <meta name="keywords" content="some,key,words">
-<meta name="descrition" content="Some description">
+<meta name="description" content="Some description">
 ```
 
 ## Usage
@@ -51,6 +51,16 @@ Would produce
 Caution: Your keywords and description MUST NOT contain a right square
 bracket(']').
 
+To create a meta "property" rather than a "name", use "metaprop" as the tag
+name. E.g.
+```
+  [metaprop:og:image https://yoursite/logo.png]
+```
+to create
+```
+  <meta property="og:image" content="https://yoursite/logo.png" />
+```
+
 Recommendation: Put your metatag autotags in the &quot;bodytext&quot; section
 of your articles to prevent them from being used on the home page and in topic
 lists. If more than one of the same tag type and priority is
@@ -67,7 +77,10 @@ Configuration UI `(http://yoursite/admin/configuration.php)`.
 #### Autotag name
 
 This is the name glFusion recognizes as an autotag (meta in the
-above USAGE)
+above USAGE).
+
+To create autotags for a meta "property", use this name as a prefix
+followed by "prop", e.g. "metaprop".
 
 #### Replace
 
@@ -94,13 +107,15 @@ To automatically add the author&apos;s name to article pages, select
 any `[meta:author]` tag will override the author set in the article.
 
 #### Defaults
-
 You can create default tags that will appear on *every* page if no autotag is
-found.. Add an element with the desired tag name and value. Use the actual
+found. Add an element with the desired tag name and value. Use the actual
 meta name value here, not the replacement key from above.
 
 Use care with this option as duplicate metatags on your site can hurt rather
 than help your search engine rankings.
+
+  * Name Tags - These elements will appear as `<meta name="key" content="value" />`
+  * Property Tags - These elements will appear as `<meta property="key" content="value" />`
 
 ## Installation
 

--- a/admin/dvlpupdate.php
+++ b/admin/dvlpupdate.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Apply updates to Birthdays during development.
+ * Calls METATAGS_upgrade() with "ignore_errors" set so repeated SQL statements
+ * won't cause functions to abort.
+ *
+ * @author      Lee Garner <lee@leegarner.com>
+ * @copyright   Copyright (c) 2018 Lee Garner <lee@leegarner.com>
+ * @package     metatags
+ * @version     v1.2.0
+ * @since       v1.2.0
+ * @license     http://opensource.org/licenses/gpl-2.0.php
+ *              GNU Public License v2 or later
+ * @filesource
+ */
+
+require_once '../../../lib-common.php';
+
+if (!SEC_inGroup('Root')) {
+    // Someone is trying to illegally access this page
+    COM_accessLog("Someone has tried to access the Birthdays Development Code Upgrade Routine without proper permissions.  User id: {$_USER['uid']}, Username: {$_USER['username']}, IP: " . $_SERVER['REMOTE_ADDR']);
+    COM_404();
+    exit;
+}
+
+require_once $_CONF['path'] . 'plugins/metatags/upgrade.inc.php';
+if (function_exists('CACHE_clear')) {
+    CACHE_clear();
+}
+
+// Force the plugin version to the previous version and do the upgrade
+$_PLUGIN_INFO['metatags']['pi_version'] = '1.1.0';
+METATAGS_do_upgrade(true);
+
+// need to clear the template cache so do it here
+if (function_exists('CACHE_clear')) {
+    CACHE_clear();
+}
+header('Location: '.$_CONF['site_admin_url'].'/plugins.php?msg=600');
+exit;

--- a/functions.inc
+++ b/functions.inc
@@ -43,15 +43,7 @@ clearstatcache();
 if (file_exists($langfile)) {
 	include_once $langfile;
 } else {
-	include_once $_CONF['path'] . 'plugins/metatags/language/english.php';
-}
-
-if (version_compare(GVERSION,'2.0.0','lt')) {
-    if (isset($LANG_configSelect['metatags']) && !isset($LANG_configselects['metatags'])) {
-        foreach ($LANG_configSelect['metatags'] AS $cfgItem) {
-            $LANG_configselects['metatags'][] = array_flip($cfgItem);
-        }
-    }
+	include_once $_CONF['path'] . 'plugins/metatags/language/english_utf-8.php';
 }
 
 /**
@@ -251,7 +243,7 @@ function plugin_templateSetVars_metatags($templatename, &$template)
         $author = !empty($A['attribution_author']) ? $A['attribution_author'] :
             COM_getDisplayName($A['uid']);
 
-        if (!empty($author)) { 
+        if (!empty($author)) {
             $out = outputHandler::getInstance();
             // Add the meta tag as "low", which is higher than the global
             // default author.
@@ -283,6 +275,13 @@ function plugin_getheadercode_metatags()
             }
         }
     }
+    if (is_array($_METATAGS_CONF['def_props'])) {
+        foreach ($_METATAGS_CONF['def_props'] as $name=>$value) {
+            if (!empty($value)) {
+                $out->addMeta('property', $name, $value, HEADER_PRIO_VERYLOW);
+            }
+        }
+    }
     return '';      // Doesn't actually return a value
 }
 
@@ -301,20 +300,35 @@ function plugin_autotags_metatags($op, $content = '', $autotag = '')
 
     switch ($op) {
     case 'tagname':
-        return $_METATAGS_CONF['tagname'];
+        return array(
+            $_METATAGS_CONF['tagname'],
+            $_METATAGS_CONF['tagname'] . 'prop',
+        );
     case 'tagusage':
         return;
     case 'desc':
         return $LANG_METATAGS['desc_meta'];
     case 'parse':
+        switch ($autotag['tag']) {
+        case $_METATAGS_CONF['tagname'] . 'prop':
+            $metaname = 'property';
+            break;
+        case $_METATAGS_CONF['tagname']:
+        default:
+            $metaname = 'name';
+            break;
+        }
         $key = strtolower($autotag['parm1']);
         $value = trim($autotag['parm2']);
-        if (is_array($_METATAGS_CONF['replace']) &&
-                isset($_METATAGS_CONF['replace'][$key]) &&
-                !empty($value)) {
+        if (
+            is_array($_METATAGS_CONF['replace']) &&
+            isset($_METATAGS_CONF['replace'][$key])
+        ) {
+            $key = $_METATAGS_CONF['replace'][$key];
+        }
+        if (!empty($value)) {
             $out = outputHandler::getInstance();
-            $out->addMeta('name', $_METATAGS_CONF['replace'][$key],
-                    $value, HEADER_PRIO_NORMAL);
+            $out->addMeta($metaname, $key, $value, HEADER_PRIO_HIGH);
         }
         // Let editors see the autotag but hide them for non-editors,
         // if so configured

--- a/install_defaults.php
+++ b/install_defaults.php
@@ -1,88 +1,142 @@
 <?php
-// +--------------------------------------------------------------------------+
-// | MetaTags Plugin for glFusion                                             |
-// +--------------------------------------------------------------------------+
-// | install_defaults.php                                                     |
-// |                                                                          |
-// | Plugin Configuration                                                     |
-// +--------------------------------------------------------------------------+
-// | $Id::                                                                   $|
-// +--------------------------------------------------------------------------+
-// | Copyright (C) 2009 by the following authors:                             |
-// |                                                                          |
-// | Mark R. Evans          mark AT glfusion DOT org                          |
-// |                                                                          |
-// | Based on the Meta Tags Plugin for Geeklog CMS                            |
-// | Copyright (C) 2009 by the following authors:                             |
-// |                                                                          |
-// | mystral-kk             - geeklog AT mystral-kk DOT net                   |
-// +--------------------------------------------------------------------------+
-// |                                                                          |
-// | This program is free software; you can redistribute it and/or            |
-// | modify it under the terms of the GNU General Public License              |
-// | as published by the Free Software Foundation; either version 2           |
-// | of the License, or (at your option) any later version.                   |
-// |                                                                          |
-// | This program is distributed in the hope that it will be useful,          |
-// | but WITHOUT ANY WARRANTY; without even the implied warranty of           |
-// | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            |
-// | GNU General Public License for more details.                             |
-// |                                                                          |
-// | You should have received a copy of the GNU General Public License        |
-// | along with this program; if not, write to the Free Software Foundation,  |
-// | Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.          |
-// |                                                                          |
-// +--------------------------------------------------------------------------+
-
+/**
+ * Configuration Defaults for the Metatags plugin for glFusion.
+ * Based on the Meta Tags Plugin for Geeklog CMS.
+ *
+ * @author      Mark R. Evans <mark AT glfusion DOT org>
+ * @copyright   Copyright (c) 2009-2022 Mark R. Evans <mark AT glfusion DOT org>
+ * @copyright   Copyright (c) 2009 mystral-kk <geeklog AT mystral-kk DOT net>
+ * @package     metatags
+ * @version     v1.2.0
+ * @license     http://opensource.org/licenses/gpl-2.0.php
+ *              GNU Public License v2 or later
+ * @filesource
+ */
 if (!defined ('GVERSION')) {
     die ('This file can not be used on its own.');
 }
 
-global $_META_DEFAULTS;
-$_META_DEFAULTS = array(
-    'tagname'   => 'meta',  // autotag name
-    'replace'   => array(
-        'key'       => 'keywords',
-        'keywords'  => 'keywords',
-        'desc'      => 'description',
-        'description' => 'description',
-        'au'        => 'author',
-        'author'    => 'author',
-        'gen'       => 'generator',
-        'generator' => 'generator',
-        'robots'    => 'robots',
+/** @var global config data */
+global $metaConfigData;
+$metaConfigData = array(
+    array(
+        'name' => 'sg_main',
+        'default_value' => NULL,
+        'type' => 'subgroup',
+        'subgroup' => 0,
+        'fieldset' => 0,
+        'selection_array' => NULL,
+        'sort' => 0,
+        'set' => true,
+        'group' => 'metatags',
     ),
-    'show_editor'   => false,   // show tags to editors in rendered contenta?
-    'keywords'      => '',      // default keywords if no tag found in content
-    'add_author'    => false,   // True to add article author automatically
-    'defaults'      => array(),
+    array(
+        'name' => 'fs_main',
+        'default_value' => NULL,
+        'type' => 'fieldset',
+        'subgroup' => 0,
+        'fieldset' => 0,
+        'selection_array' => NULL,
+        'sort' => 0,
+        'set' => true,
+        'group' => 'metatags',
+    ),
+    array(
+        'name' => 'tagname',        // autotag name
+        'default_value' => 'meta',
+        'type' => 'text',
+        'subgroup' => 0,
+        'fieldset' => 0,
+        'selection_array' => 0,
+        'sort' => 10,
+        'set' => true,
+        'group' => 'metatags',
+    ),
+    array(
+        'name' => 'replace',        // allow short names in autotags
+        'default_value' => array(
+            'key'       => 'keywords',
+            'keywords'  => 'keywords',
+            'desc'      => 'description',
+            'description' => 'description',
+            'au'        => 'author',
+            'author'    => 'author',
+            'gen'       => 'generator',
+            'generator' => 'generator',
+            'robots'    => 'robots',
+        ),
+        'type' => '*text',
+        'subgroup' => 0,
+        'fieldset' => 0,
+        'selection_array' => 0,
+        'sort' => 20,
+        'set' => true,
+        'group' => 'metatags',
+    ),
+    array(
+        'name' => 'show_editor',    // show tags to editors in rendered contents?
+        'default_value' => false,
+        'type' => 'select',
+        'subgroup' => 0,
+        'fieldset' => 0,
+        'selection_array' => 0,
+        'sort' => 30,
+        'set' => true,
+        'group' => 'metatags',
+    ),
+    array(
+        'name' => 'add_author',     // True to add article author automatically
+        'default_value' => false,
+        'type' => 'select',
+        'subgroup' => 0,
+        'fieldset' => 0,
+        'selection_array' => 0,
+        'sort' => 40,
+        'set' => true,
+        'group' => 'metatags',
+    ),
+    array(
+        'name' => 'defaults',
+        'default_value' => array(),
+        'type' => '*text',
+        'subgroup' => 0,
+        'fieldset' => 0,
+        'selection_array' => 0,
+        'sort' => 50,
+        'set' => true,
+        'group' => 'metatags',
+    ),
+    array(
+        'name' => 'def_props',
+        'default_value' => array(),
+        'type' => '*text',
+        'subgroup' => 0,
+        'fieldset' => 0,
+        'selection_array' => 0,
+        'sort' => 60,
+        'set' => true,
+        'group' => 'metatags',
+    ),
 );
 
+
 /**
-* Initialize Metatags plugin configuration
-*
-* Creates the database entries for the configuation if they don't already
-* exist.  Initial values will be taken from $_METATAGS_DEFAULT
-* if available (e.g. from an old config.php), uses $_METATAGS_DEFAULT
-* otherwise.
-*
-* @return   boolean     TRUE: success; FALSE: an error occurred
-*
-*/
+ * Initialize Metatags plugin configuration.
+ *
+ * @return  boolean     True on success, False on error (not used)
+ */
 function plugin_initconfig_metatags()
 {
-    global $_METATAGS_CONF, $_META_DEFAULTS;
+    global $metaConfigData;
 
     $c = config::get_instance();
-    $pi = $_METATAGS_CONF['pi_name'];
-    $c->add('sg_main', NULL, 'subgroup', 0, 0, NULL, 0, TRUE, $pi);
-    $c->add('fs_main', NULL, 'fieldset', 0, 0, NULL, 0, TRUE, $pi);
-    $c->add('tagname', $_META_DEFAULTS['tagname'], 'text', 0, 0, NULL, 10, TRUE, $pi);
-    $c->add('replace', $_META_DEFAULTS['replace'], '*text', 0, 0, NULL, 20, TRUE, $pi);
-    $c->add('add_author', $_META_DEFAULTS['add_author'], 'select', 0, 0, 1, 30, TRUE, $pi);
-    $c->add('show_editor', $_META_DEFAULTS['show_editor'], 'select', 0, 0, 1, 40, TRUE, $pi);
-    $c->add('defaults', $_META_DEFAULTS['defaults'], '*text', 0, 0, NULL, 50, TRUE, $pi);
-
-    return TRUE;
+    if (!$c->group_exists('metatags')) {
+        USES_lib_install();
+        foreach ($metaConfigData AS $cfgItem) {
+            _addConfigItem($cfgItem);
+        }
+    } else {
+        Log::system(Log::ERROR, 'initconfig error: Metatags config group already exists');
+    }
+    return true;
 }
-?>

--- a/language/dutch_utf-8.php
+++ b/language/dutch_utf-8.php
@@ -51,10 +51,10 @@ $LANG_configsections['metatags'] = array(
 $LANG_confignames['metatags'] = array(
     'tagname' => 'Autotag naam',
     'replace' => 'Vervang',
-    'description' => 'Standaard beschrijving',
     'show_editor' => 'Display autotags for content edtiors',
-    'add_author' => 'Add article author name autmatically',
-    'defaults' => 'Default Meta Name Tags'
+    'add_author'  => 'Add article author name autmatically',
+    'defaults'    => 'Default Meta Name Tags',
+    'def_props'   => 'Default Meta Property Tags',
 );
 
 $LANG_configsubgroups['metatags'] = array(
@@ -65,12 +65,7 @@ $LANG_fs['metatags'] = array(
     'fs_main' => 'Metatags Hoofd Instellingen'
 );
 
-// Note: entries 0, 1, and 12 are the same as in $LANG_configselects['Core']
-$LANG_configselects['metatags'] = array(
-    0 => array('Ja' => 1, 'Nee' => 0),
-    1 => array('Ja' => true, 'Nee' => false),
-    9 => array('Ga naar pagina' => 'item', 'Toon Lijst' => 'list', 'Toon Startpagina' => 'home', 'Toon Beheerpagina' => 'admin'),
-    12 => array('No access' => 0, 'Read-Only' => 2, 'Read-Write' => 3)
+$LANG_configSelect['metatags'] = array(
+    0 => array(1 => 'Ja', 0 => 'Nee'),
+    1 => array(TRUE => 'Ja', FALSE => 'Nee'),
 );
-
-?>

--- a/language/english_utf-8.php
+++ b/language/english_utf-8.php
@@ -50,10 +50,10 @@ $LANG_configsections['metatags'] = array(
 $LANG_confignames['metatags'] = array(
     'tagname'     => 'Autotag name',
     'replace'     => 'Replace',
-    'description' => 'Default Description',
     'show_editor' => 'Display autotags for content edtiors',
     'add_author'  => 'Add article author name autmatically',
     'defaults'    => 'Default Meta Name Tags',
+    'def_props'   => 'Default Meta Property Tags',
 );
 
 $LANG_configsubgroups['metatags'] = array(
@@ -64,11 +64,7 @@ $LANG_fs['metatags'] = array(
     'fs_main'       => 'Metatags Main Settings',
 );
 
-// Note: entries 0, 1, 9, and 12 are the same as in $LANG_configselects['Core']
-$LANG_configselects['metatags'] = array(
-    0 => array('True' => 1, 'False' => 0),
-    1 => array('True' => TRUE, 'False' => FALSE),
-    9 => array('Forward to page' => 'item', 'Display List' => 'list', 'Display Home' => 'home', 'Display Admin' => 'admin'),
-    12 => array('No access' => 0, 'Read-Only' => 2, 'Read-Write' => 3),
+$LANG_configSelect['metatags'] = array(
+    0 => array(1 => 'True', 0 => 'False'),
+    1 => array(1 => 'True', 0 => 'False'),
 );
-?>

--- a/language/german_utf-8.php
+++ b/language/german_utf-8.php
@@ -51,10 +51,10 @@ $LANG_configsections['metatags'] = array(
 $LANG_confignames['metatags'] = array(
     'tagname' => 'Autotag-Name',
     'replace' => 'Ersetzen',
-    'description' => 'Standardbeschreibung',
     'show_editor' => 'Autotags für Inhalte-Editoren anzeigen',
-    'add_author' => 'Add article author name autmatically',
-    'defaults' => 'Default Meta Name Tags'
+    'add_author'  => 'Add article author name autmatically',
+    'defaults'    => 'Default Meta Name Tags',
+    'def_props'   => 'Default Meta Property Tags',
 );
 
 $LANG_configsubgroups['metatags'] = array(
@@ -65,12 +65,7 @@ $LANG_fs['metatags'] = array(
     'fs_main' => 'Metatags-Haupteinstellungen'
 );
 
-// Note: entries 0, 1, and 12 are the same as in $LANG_configselects['Core']
-$LANG_configselects['metatags'] = array(
-    0 => array('Ja' => 1, 'Nein' => 0),
-    1 => array('Ja' => true, 'Nein' => false),
-    9 => array('Weiterleiten zu Seite' => 'item', 'Liste anzeigen' => 'list', 'Home anzeigen' => 'home', 'Admin anzeigen' => 'admin'),
-    12 => array('Kein Zugriff' => 0, 'Nur-Lesen' => 2, 'Lesen-Schreiben' => 3)
+$LANG_configSelect['metatags'] = array(
+    0 => array(1 => 'Ja', 0 => 'Nein'),
+    1 => array(TRUE => 'Ja', FALSE => 'Nein'),
 );
-
-?>

--- a/language/japanese_utf-8.php
+++ b/language/japanese_utf-8.php
@@ -53,8 +53,9 @@ $LANG_confignames['metatags'] = array(
     'replace' => '置換ルール',
     'description' => 'descriptionの初期値',
     'show_editor' => 'Display autotags for content edtiors',
-    'add_author' => 'Add article author name autmatically',
-    'defaults' => 'Default Meta Name Tags'
+    'add_author'  => 'Add article author name autmatically',
+    'defaults'    => 'Default Meta Name Tags',
+    'def_props'   => 'Default Meta Property Tags',
 );
 
 $LANG_configsubgroups['metatags'] = array(
@@ -65,12 +66,7 @@ $LANG_fs['metatags'] = array(
     'fs_main' => 'メタタグの主要設定'
 );
 
-// Note: entries 0, 1, and 12 are the same as in $LANG_configselects['Core']
-$LANG_configselects['metatags'] = array(
-    0 => array('はい' => 1, 'いいえ' => 0),
-    1 => array('はい' => true, 'いいえ' => false),
-    9 => array('Forward to page' => 'item', 'Display List' => 'list', 'Display Home' => 'home', 'Display Admin' => 'admin'),
-    12 => array('アクセス不可' => 0, '表示' => 2, '表示・編集' => 3)
+$LANG_configSelect['metatags'] = array(
+    0 => array(1 => 'はい', 0 => 'いいえ'),
+    1 => array(TRUE => 'はい', FALSE => 'いいえ'),
 );
-
-?>

--- a/metatags.php
+++ b/metatags.php
@@ -35,7 +35,6 @@ if (!defined ('GVERSION')) {
 // Plugin info
 $_METATAGS_CONF['pi_name']          = 'metatags';
 $_METATAGS_CONF['pi_display_name']  = 'MetaTags';
-$_METATAGS_CONF['pi_version']       = '1.1.0.1';
+$_METATAGS_CONF['pi_version']       = '1.2.0';
 $_METATAGS_CONF['gl_version']       = '2.0.0';
 $_METATAGS_CONF['pi_url']           = 'http://www.glfusion.org/';
-?>

--- a/metatags.php
+++ b/metatags.php
@@ -35,7 +35,7 @@ if (!defined ('GVERSION')) {
 // Plugin info
 $_METATAGS_CONF['pi_name']          = 'metatags';
 $_METATAGS_CONF['pi_display_name']  = 'MetaTags';
-$_METATAGS_CONF['pi_version']       = '1.1.0';
-$_METATAGS_CONF['gl_version']       = '1.7.0';
+$_METATAGS_CONF['pi_version']       = '1.1.0.1';
+$_METATAGS_CONF['gl_version']       = '2.0.0';
 $_METATAGS_CONF['pi_url']           = 'http://www.glfusion.org/';
 ?>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,9 +2,9 @@
     <id>metatags</id>
     <name>MetaTags</name>
     <description>Allows content authors to add meta keywords and descriptions to the HTML header for articles and static pages.</description>
-    <version>1.1.0</version>
-    <glfusionversion>1.7.0</glfusionversion>
-    <phpversion>5.6.0</phpversion>
+    <version>1.1.0.1</version>
+    <glfusionversion>2.0.0</glfusionversion>
+    <phpversion>7.4.0</phpversion>
     <url>http://www.glfusion.org</url>
     <maintainer>Mark R. Evans</maintainer>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
     <id>metatags</id>
     <name>MetaTags</name>
     <description>Allows content authors to add meta keywords and descriptions to the HTML header for articles and static pages.</description>
-    <version>1.1.0.1</version>
+    <version>1.2.0</version>
     <glfusionversion>2.0.0</glfusionversion>
     <phpversion>7.4.0</phpversion>
     <url>http://www.glfusion.org</url>

--- a/upgrade.inc.php
+++ b/upgrade.inc.php
@@ -1,27 +1,27 @@
 <?php
 /**
-*   Upgrade routines for the Metatags plugin.
-*
-*   @author     Lee Garner <lee@leegarner.com>
-*   @copyright  Copyright (c) 2017 Lee Garner <lee@leegarner.com>
-*   @package    metatags
-*   @version    1.1.0
-*   @license    http://opensource.org/licenses/gpl-2.0.php
-*               GNU Public License v2 or later
-*   @filesource
-*/
+ * Upgrade routines for the Metatags plugin.
+ *
+ * @author      Lee Garner <lee@leegarner.com>
+ * @copyright   Copyright (c) 2017-2022 Lee Garner <lee@leegarner.com>
+ * @package     metatags
+ * @version     v1.2.0
+ * @license     http://opensource.org/licenses/gpl-2.0.php
+ *              GNU Public License v2 or later
+ * @filesource
+ */
 
 /** Include the default configuration values */
 require_once __DIR__ . '/install_defaults.php';
 
 
 /**
-*   Perform the upgrade starting at the current version.
-*
-*   @since  version 0.4.0
-*   @return integer                 Error code, 0 for success
-*/
-function METATAGS_do_upgrade()
+ * Perform the upgrade starting at the current version.
+ *
+ * @since   v0.4.0
+ * @return  boolean     True for success, False on error
+ */
+function METATAGS_do_upgrade($dvlp=false)
 {
     global $_CONF, $_TABLES, $_METATAGS_CONF, $_META_DEFAULTS, $_PLUGIN_INFO;
 
@@ -45,9 +45,6 @@ function METATAGS_do_upgrade()
     if (!COM_checkVersion($current_ver, '1.0.4')) {
         // upgrade to 1.0.4
         $current_ver = '1.0.4';
-           $c->add('sp_php', false, 'select', 0, 0, 1, 30, TRUE, $pi_name);
-           $c->add('replace', $_META_DEFAULTS['replace'], '*text', 0, 0, NULL, 20, TRUE, $pi_name);
-           $c->add('show_editor', $_META_DEFAULTS['show_editor'], 'select', 0, 0, 1, 40, TRUE, $pi_name);
         if (!METATAGS_do_set_version($current_ver)) return false;
     }
 
@@ -84,6 +81,12 @@ function METATAGS_do_upgrade()
         if (!METATAGS_do_set_version($current_ver)) return false;
     }
 
+    // Update any configuration item changes
+    USES_lib_install();
+    global $metaConfigData;
+    require_once __DIR__ . '/install_defaults.php';
+    _update_config('metatags', $metaConfigData);
+
     CTL_clearCache($pi_name);
     COM_errorLog("Successfully updated the {$_METATAGS_CONF['pi_display_name']} Plugin", 1);
     return true;
@@ -91,13 +94,13 @@ function METATAGS_do_upgrade()
 
 
 /**
-*   Update the plugin version number in the database.
-*   Called at each version upgrade to keep up to date with
-*   successful upgrades.
-*
-*   @param  string  $ver    New version to set
-*   @return boolean         True on success, False on failure
-*/
+ * Update the plugin version number in the database.
+ * Called at each version upgrade to keep up to date with
+ * successful upgrades.
+ *
+ * @param   string  $ver    New version to set
+ * @return  boolean         True on success, False on failure
+ */
 function METATAGS_do_set_version($ver)
 {
     global $_TABLES, $_METATAGS_CONF;
@@ -118,5 +121,3 @@ function METATAGS_do_set_version($ver)
         return true;
     }
 }
-
-?>


### PR DESCRIPTION
Add config option for default meta properties.
The change to the outputhandler class in https://github.com/glFusion/glfusion/pull/590 is required to properly handle priorities for properties.